### PR TITLE
spec: restructure Knowledge Repositories as L3 headings with capability flags

### DIFF
--- a/Example/.claude/fabric-core.md
+++ b/Example/.claude/fabric-core.md
@@ -229,7 +229,41 @@ This principle applies during ingestion, evaluation, triage, and any conversatio
 
 ### Knowledge Repository Nudges
 
-When ingesting content that references external artifacts, nudge (do not block) the user about filing in appropriate external systems. Teams should customize these nudges in their CLAUDE.md based on their knowledge repositories.
+Teams define their knowledge repositories in the `## Knowledge Repositories` section of their CLAUDE.md using level-3 headings — one heading per repository. During `/ingest` and `/refine`, evaluate content against all defined repositories and nudge (do not block) the user when something looks like it belongs in one of them. Use the free-form description under each heading to inform what triggers a nudge for that repository.
+
+#### Repository Entry Format
+
+```markdown
+### Repository Name
+Readable: Yes          # optional — default No
+Writable: Yes          # optional — default No
+Expect-Local: Yes      # optional — default No; signals a local clone is expected
+URL: https://...       # optional — web URL or git remote
+
+Free-form description: what lives here, what triggers a nudge, how the team uses it.
+```
+
+All fields are optional. A minimal entry is just a heading and description.
+
+#### Local Path Resolution
+
+When `Expect-Local: Yes` is set, the agent expects a sibling directory next to the Fabric instance:
+- If `URL:` is present: infer the folder name from the last path segment of the URL (e.g. `https://github.com/org/internal-docs` → `../internal-docs`).
+- If no `URL:`: use the heading name lowercased and hyphenated.
+
+The sibling check is **lazy** — performed only when the agent actually attempts to read or write the repository, not on session load. If the folder is not found at that moment, surface a warning and continue:
+
+> "We are unable to locate [repo name] at [expected path]. Clone the repository to enable [read/write] access."
+
+#### Readable Behavior
+
+When `Readable: Yes` and `Expect-Local: Yes`: the agent may read from the sibling folder to provide context (recent content, existing pages) when relevant to the current ingest or refine session. Do not read proactively on every query — read on demand when the content would improve a nudge or answer.
+
+#### Writable Behavior
+
+When `Writable: Yes` and `Expect-Local: Yes`: the agent may propose drafting content into the sibling folder. Always propose the draft content and target path for confirmation before writing. After writing:
+1. Append a context log entry to the originating entity noting the draft path and date.
+2. Remind the user that they need to go to that repository to review and commit the draft — the agent does not commit on their behalf.
 
 ### Constraints
 

--- a/Example/CLAUDE.md
+++ b/Example/CLAUDE.md
@@ -39,9 +39,26 @@ Iteration Duration: 14 days
 
 ## Knowledge Repositories
 
-- Confluence: team wiki and runbooks
-- GitHub: source repositories
-- Shared Drive: project documentation and reports
+### Confluence
+URL: https://riverdale.atlassian.net/wiki
+Team wiki and runbooks. Nudge when ingested content is a reusable procedure,
+onboarding step, or operational runbook. Nudge when a retro action item results
+in a documented process change.
+
+### GitHub
+URL: https://github.com/riverdale-de
+Source repositories. Reference only — no local read needed beyond linked repos
+on individual requests and epics.
+
+### Internal Docs
+Readable: Yes
+Writable: Yes
+Expect-Local: Yes
+URL: https://github.com/riverdale-de/internal-docs
+MkDocs site for internal engineering documentation. Read existing pages before
+suggesting new ones to avoid duplication. Write draft pages to docs/drafts/ —
+team reviews and commits from that repository. Nudge when ingested content
+describes environment setup, cross-product patterns, or recurring operational steps.
 
 ## Notification Rules
 

--- a/Fabric/template/CLAUDE.md
+++ b/Fabric/template/CLAUDE.md
@@ -41,8 +41,18 @@
 
 ## Knowledge Repositories
 
-<!-- Where does your team's content live? SharePoint, shared drives, wikis, repos? -->
-<!-- The AI uses this section to generate nudges when ingesting content. -->
+<!--
+  One level-3 heading per repository. All fields are optional — a minimal entry is
+  just a heading and a description of what lives there and what triggers a nudge.
+
+  ### My Repo
+  Readable: Yes          # agent can read local clone for context (requires Expect-Local)
+  Writable: Yes          # agent can draft content into local clone (requires Expect-Local)
+  Expect-Local: Yes      # expect a sibling folder; warn lazily if not found
+  URL: https://...       # web URL or git remote; last path segment = expected folder name
+
+  Description: what lives here, what triggers a nudge, how the team uses it.
+-->
 
 ## Notification Rules
 

--- a/Fabric/template/fabric-core.md
+++ b/Fabric/template/fabric-core.md
@@ -229,7 +229,41 @@ This principle applies during ingestion, evaluation, triage, and any conversatio
 
 ### Knowledge Repository Nudges
 
-When ingesting content that references external artifacts, nudge (do not block) the user about filing in appropriate external systems. Teams should customize these nudges in their CLAUDE.md based on their knowledge repositories.
+Teams define their knowledge repositories in the `## Knowledge Repositories` section of their CLAUDE.md using level-3 headings — one heading per repository. During `/ingest` and `/refine`, evaluate content against all defined repositories and nudge (do not block) the user when something looks like it belongs in one of them. Use the free-form description under each heading to inform what triggers a nudge for that repository.
+
+#### Repository Entry Format
+
+```markdown
+### Repository Name
+Readable: Yes          # optional — default No
+Writable: Yes          # optional — default No
+Expect-Local: Yes      # optional — default No; signals a local clone is expected
+URL: https://...       # optional — web URL or git remote
+
+Free-form description: what lives here, what triggers a nudge, how the team uses it.
+```
+
+All fields are optional. A minimal entry is just a heading and description.
+
+#### Local Path Resolution
+
+When `Expect-Local: Yes` is set, the agent expects a sibling directory next to the Fabric instance:
+- If `URL:` is present: infer the folder name from the last path segment of the URL (e.g. `https://github.com/org/internal-docs` → `../internal-docs`).
+- If no `URL:`: use the heading name lowercased and hyphenated.
+
+The sibling check is **lazy** — performed only when the agent actually attempts to read or write the repository, not on session load. If the folder is not found at that moment, surface a warning and continue:
+
+> "We are unable to locate [repo name] at [expected path]. Clone the repository to enable [read/write] access."
+
+#### Readable Behavior
+
+When `Readable: Yes` and `Expect-Local: Yes`: the agent may read from the sibling folder to provide context (recent content, existing pages) when relevant to the current ingest or refine session. Do not read proactively on every query — read on demand when the content would improve a nudge or answer.
+
+#### Writable Behavior
+
+When `Writable: Yes` and `Expect-Local: Yes`: the agent may propose drafting content into the sibling folder. Always propose the draft content and target path for confirmation before writing. After writing:
+1. Append a context log entry to the originating entity noting the draft path and date.
+2. Remind the user that they need to go to that repository to review and commit the draft — the agent does not commit on their behalf.
 
 ### Constraints
 


### PR DESCRIPTION
## Summary

- Replaces the free-form bullet list in `## Knowledge Repositories` with a structured L3-heading format, one heading per repository
- Adds optional `Readable`, `Writable`, `Expect-Local`, and `URL` fields per entry; all default to No/absent
- Local sibling path is inferred lazily from the URL's last segment (or heading name); missing clones surface a warning only when access is attempted
- Nudges now fire on both `/ingest` and `/refine`, informed by each repo's free-form description
- Writable repos receive proposed draft content with a context log entry on the originating entity; the human reviews and commits from the target repo

## Test plan

- [ ] Review updated `Fabric/template/fabric-core.md` behavioral spec for completeness and edge cases
- [ ] Review updated `Fabric/template/CLAUDE.md` comment block — does it communicate the format clearly to a new team?
- [ ] Review `Example/CLAUDE.md` — does the Riverdale example illustrate the range of usage (nudge-only, read, read+write)?
- [ ] Verify `Example/.claude/fabric-core.md` matches the template version

Closes #10