### PR TITLE
spec: add /stakeholder command for stakeholder lifecycle management

### DIFF
--- a/Example/.claude/fabric-core.md
+++ b/Example/.claude/fabric-core.md
@@ -153,6 +153,7 @@ The `staging/` directory is a drop zone for raw content. All contents except `RE
 | Command | Description |
 |---------|-------------|
 | /member | Member lifecycle and capacity management. Subcommands: `add` (requires meta mode), `depart` (requires meta mode), `activate` (requires meta mode), `timeoff` (meta mode required only when recording for another member). |
+| /stakeholder | Stakeholder lifecycle management. Subcommands: `add` (requires meta mode), `depart` (requires meta mode), `activate` (requires meta mode). |
 | /readme | Regenerate README.md from current state of CLAUDE.md, team/team.md, and member profiles. |
 | /describe-team | Synthesize a narrative description of the team from all sources. Optionally accepts an audience hint (e.g., "for leadership", "for onboarding"). Surfaces inconsistencies, gaps, or staleness. |
 | /status | Quick summary of team state: active members and allocation, engagement counts, pending requests. |

--- a/Fabric/.claude/commands/stakeholder.md
+++ b/Fabric/.claude/commands/stakeholder.md
@@ -1,0 +1,120 @@
+# /stakeholder - Stakeholder Lifecycle Management
+
+## Purpose
+Unified stakeholder lifecycle management — onboarding, profile updates, and departure.
+
+## Usage
+
+```
+/stakeholder <subcommand> [args]
+```
+
+With no subcommand, list the available subcommands and one-line descriptions.
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| add | Guided creation of a new stakeholder profile |
+| depart [name] | Set a stakeholder's status to Departed |
+| activate [name] | Restore a departed stakeholder to Active |
+
+---
+
+## /stakeholder add
+
+### Purpose
+Guided creation of a new stakeholder profile.
+
+### Prerequisites
+- Meta mode must be active. If not, prompt the user to enter meta mode first.
+
+### Behavior
+
+1. Collect stakeholder information:
+   - Name
+   - Role / title
+   - Organization (their organization or team)
+   - Summary (2-3 sentences describing their relationship to the team, influence, and priorities)
+   - Areas of interest (list)
+   - Expertise (list)
+   - Communication preferences (how they prefer to receive updates — channel, frequency, detail level, tone)
+   - Contact info: email (optional), preferred channel
+
+2. Generate the profile:
+   - Create directory: team/stakeholders/<name-slug>/
+   - Create profile.md with Status: Active
+
+3. Update team/team.md:
+   - Add row to Stakeholders table
+
+4. Present changes for confirmation before writing.
+
+### Template
+Use team/stakeholders/template/profile.md as the starting point for new profiles. The template directory is not a real stakeholder and should be excluded from stakeholder scans.
+
+### Slug Convention
+Stakeholder directory names use lowercase hyphenated full names: `theresa-blount`, `raj-mehta`.
+
+### Valid Status Values
+- Active: engaged stakeholder, surfaced in relevant communications and decisions
+- Departed: inactive but preserved, excluded from active surfacing
+
+---
+
+## /stakeholder depart
+
+### Purpose
+Set a stakeholder's status to Departed. The profile and all context log references are preserved. The stakeholder is excluded from active surfacing in communications, escalations, and decision recommendations.
+
+### Prerequisites
+- Meta mode must be active.
+
+### Behavior
+
+1. Accept a stakeholder name (fuzzy match against existing profiles).
+
+2. Confirm the action: "Mark [name] as Departed? They will be excluded from active surfacing in communications and decisions. Their profile and all context references will be preserved."
+
+3. Update the stakeholder's profile:
+   - Set Status: Departed
+   - Write `Terminated: <today's date>` to the header fields.
+   - Append to their context log: "- YYYY-MM-DD - /stakeholder depart: Status changed to Departed. [reason if provided]"
+
+4. Update team/team.md:
+   - Mark the stakeholder's row or move to a Departed section in the Stakeholders table
+
+5. Present changes for confirmation before writing.
+
+### Notes
+- Departure is reversible via `/stakeholder activate`.
+- The AI should never suggest removing or deleting a stakeholder. `/stakeholder depart` is the correct action.
+- Context log entries that reference a departed stakeholder remain valid and unchanged.
+
+---
+
+## /stakeholder activate
+
+### Purpose
+Restore a departed stakeholder to Active status.
+
+### Prerequisites
+- Meta mode must be active.
+
+### Behavior
+
+1. Accept a stakeholder name (fuzzy match, filtered to Departed stakeholders).
+   - If no departed stakeholders exist, inform the user.
+
+2. Optionally update role, organization, or communication preferences if they have changed since departure.
+
+3. Update the stakeholder's profile:
+   - Set Status: Active
+   - Remove the `Terminated:` line entirely from the header fields.
+   - Update any changed fields
+   - Append to context log: "- YYYY-MM-DD - /stakeholder activate: Status changed to Active. [notes if any]"
+
+4. Update team/team.md:
+   - Restore the stakeholder's row to the active Stakeholders table
+
+5. Present changes for confirmation before writing.

--- a/Fabric/template/fabric-core.md
+++ b/Fabric/template/fabric-core.md
@@ -153,6 +153,7 @@ The `staging/` directory is a drop zone for raw content. All contents except `RE
 | Command | Description |
 |---------|-------------|
 | /member | Member lifecycle and capacity management. Subcommands: `add` (requires meta mode), `depart` (requires meta mode), `activate` (requires meta mode), `timeoff` (meta mode required only when recording for another member). |
+| /stakeholder | Stakeholder lifecycle management. Subcommands: `add` (requires meta mode), `depart` (requires meta mode), `activate` (requires meta mode). |
 | /readme | Regenerate README.md from current state of CLAUDE.md, team/team.md, and member profiles. |
 | /describe-team | Synthesize a narrative description of the team from all sources. Optionally accepts an audience hint (e.g., "for leadership", "for onboarding"). Surfaces inconsistencies, gaps, or staleness. |
 | /status | Quick summary of team state: active members and allocation, engagement counts, pending requests. |


### PR DESCRIPTION
## Summary

- Adds `Fabric/.claude/commands/stakeholder.md` with `add`, `depart`, and `activate` subcommands, mirroring `/member` (no `timeoff` — stakeholders have no capacity/allocation)
- Registers `/stakeholder` in the Core Commands table in `Fabric/template/fabric-core.md` and `Example/.claude/fabric-core.md`
- No schema changes needed — the stakeholder profile template already had `Status:` and `Terminated:` fields

Closes #8.

## Test plan

- [ ] `/stakeholder` with no subcommand lists available subcommands
- [ ] `/stakeholder add` requires meta mode, collects info, creates profile under `team/stakeholders/<slug>/`, updates `team.md`
- [ ] `/stakeholder depart` sets `Status: Departed`, writes `Terminated:` date, appends to context log, updates `team.md`
- [ ] `/stakeholder activate` restores status, removes `Terminated:`, updates `team.md`
- [ ] Departed stakeholders are excluded from active surfacing in communications/decisions