### PR TITLE
fix: Example/CLAUDE.md drift — remove Decision Log, add drift discipline convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ Use Example/ to test ingestion, evaluation, and other workflows without touching
 - Work-specific content (RAIS rubrics, real request data) should wait for the work machine. Keep framework development general-purpose.
 - Structural files in Fabric/ are governed by the meta mode convention. When advising on changes to the constitution or skills, respect that separation even though you are not bound by it.
 - The design summary (`fabric-design-summary.md`) is the foundational reference. Significant departures from it should be discussed, not silently introduced.
+- **Example/ drift discipline:** Any change to `Fabric/template/` or `Fabric/backlog/template-*.md` requires a sweep of `Example/` to keep it in sync. The Example is the public signal of framework discipline — it must reflect the current state of the templates. Update `Example/` in the same commit as the template change. This applies to structural removals (sections dropped from templates), additions (new sections or fields), and schema changes.
 
 ## Execution Mode
 

--- a/Example/CLAUDE.md
+++ b/Example/CLAUDE.md
@@ -82,7 +82,3 @@ describes environment setup, cross-product patterns, or recurring operational st
 | Effort Tracking | Enabled | Capture actual hours on close, rollup to parent |
 | Standup | Enabled | Daily standup conversations and team summary |
 | Retrospective | Enabled | Periodic retros with team summary and action item routing |
-
-## Decision Log
-
-- 2026-03-28: Adopted Fabric as team working memory system. Context: Growing request volume needs structured triage.

--- a/Fabric/.claude/commands/member.md
+++ b/Fabric/.claude/commands/member.md
@@ -89,6 +89,21 @@ Set a member's status to Departed. The profile and all context log references ar
 
 5. Present changes for confirmation before writing.
 
+6. **Cascade scan** (after writing state change): scan all backlog entity files for assignments referencing the departed member. Match against:
+   - `Assigned to:` fields
+   - `Owners:` fields
+
+   For each entity found, propose reassignment or clearing the field. Work through affected entities one at a time:
+   ```
+   [Member name] is listed as [Assigned to / Owner] on the following items:
+   - [entity name] — Assigned to
+
+   Reassign [entity name] to another member, or clear the field? (reassign / clear / skip)
+   ```
+   If reassigning, suggest active members as options. Follow propose-confirm-write for each entity.
+
+   If no assignments are found, note this and conclude.
+
 ### Notes
 - Departure is reversible via `/member activate`.
 - The AI should never suggest removing or deleting a member. `/member depart` is the correct action.

--- a/Fabric/.claude/skills/entity-transitions.md
+++ b/Fabric/.claude/skills/entity-transitions.md
@@ -96,6 +96,31 @@ When invoked implicitly, identify the target entity and desired state from conte
 
 9. On confirmation: set `State: Resolved` or `State: Closed` as appropriate for the entity type. Update any confirmed explicit DoD checkboxes. Write `Terminated: <today's date>` to the Properties block if not already set.
 
+10. **Cascade scan** (after writing state change): scan for entities that reference this entity and may need updating. Work through each category in order; skip any with no results.
+
+    a. **Dependency cascade**: search all entity files for `## Items this depends on` sections referencing this entity (match by ID or title). For each found:
+       - Propose removing the dependency entry (the work is done — the dependency is resolved).
+       - Follow propose-confirm-write for each affected entity, one at a time.
+       ```
+       [Entity Title] has been closed. The following entities list it as a dependency:
+       - [entity name] — Items this depends on
+
+       Remove this dependency entry from [entity name]? (yes / no / skip all)
+       ```
+
+    b. **Related Items (informational)**: search all entity files for `## Related Items` sections referencing this entity. Surface each as informational — no write action required.
+       ```
+       FYI — these entities list [Entity Title] in Related Items:
+       - [entity name]
+       No action needed unless the relationship is no longer relevant.
+       ```
+
+    c. **Request cascade** (epics only): if closing an epic, scan all request files for `Backlog Epic:` fields pointing to this epic. Surface each and ask whether to clear the field or leave it as a historical reference.
+       ```
+       Request [R-NNN] references this epic in Backlog Epic:.
+       Clear the Backlog Epic field, or leave as historical reference? (clear / leave)
+       ```
+
 ---
 
 ### Any → Removed
@@ -124,8 +149,26 @@ When invoked implicitly, identify the target entity and desired state from conte
    - Set `State: Removed`.
    - Write `Terminated: <today's date>` to the Properties block if not already set.
    - Do NOT delete the file.
-   - Suggest a git commit: "Recommend committing this change: `git commit -m 'Remove [entity title]'`"
-5. Offer to open the dependent entities to update their references, one at a time.
+
+5. **Cascade updates** (after writing state change): work through each affected entity found in step 2, proposing concrete updates one at a time. Follow propose-confirm-write for each.
+
+   - **`## Items this depends on` references**: propose removing the entry from the dependent entity.
+     ```
+     [Dependent entity name] lists this item as a dependency.
+     Remove the dependency entry? (yes / no / skip all)
+     ```
+   - **`## Related Items` references**: surface as informational. Ask whether to remove or leave.
+     ```
+     [Entity name] lists this item in Related Items.
+     Remove the reference, or leave it? (remove / leave)
+     ```
+   - **`Backlog Epic:` references** (epics only): propose clearing the field.
+     ```
+     Request [R-NNN] references this epic in Backlog Epic:.
+     Clear the field? (yes / no)
+     ```
+
+   After all cascades are resolved, suggest a git commit: "Recommend committing these changes: `git commit -m 'Remove [entity title] and update references'`"
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes `## Decision Log` from `Example/CLAUDE.md` — this section was dropped from the framework template when per-entity Decisions sections landed, but was never cleaned up in Example
- Adds a **drift discipline** working convention to the root `CLAUDE.md`: any change to `Fabric/template/` or `Fabric/backlog/template-*.md` must include a sweep of `Example/` in the same commit

Closes #15