### PR TITLE
feat: route standup backlog notes to Context Log

### DIFF
--- a/Example/.claude/fabric-standup.md
+++ b/Example/.claude/fabric-standup.md
@@ -88,13 +88,23 @@ Each `discuss-today.md` uses this structure:
 
 ### Backlog Notes from Standup
 
-During standup, a member may mention something worth capturing on a backlog item — a discovery, a risk, a decision made, a dependency identified. At the end of the conversation, the agent reviews the discussion for such items and offers to append a dated note to the relevant entity file.
+During standup, a member may mention something worth capturing on a backlog item — a discovery, a risk, a decision made, a dependency identified, or a blocker. At the end of the conversation, the agent reviews the discussion for such items and offers to route each one to the appropriate section of the relevant entity file.
 
-- Notes are appended to a `## Notes` section on the backlog entity. If the section does not exist, it is created.
-- Note format: `- YYYY-MM-DD [standup]: [note text]`
-- The agent offers once per item, does not write without confirmation, and does not change status or priority — notes only.
-- If the member cannot identify the item, the agent may search `backlog/` by keyword and propose the best match for confirmation.
+**Routing by type:**
+
+| What was mentioned | Route to |
+|--------------------|----------|
+| Blocker ("I'm blocked on X", "can't proceed until Y") | `## Blockers` entry + set `Blocked: Yes` in Properties |
+| Open question ("we need to figure out X", "TBD") | `## Open Questions` checkbox item |
+| Decision made ("we decided to...", "going with X") | `## Decisions` entry |
+| General discovery, risk, or context | `## Context Log` entry |
+
+For blockers specifically: ask who flagged it (defaults to the standup member), what the cause is (open question, dependency, external, other), and whether it relates to an existing open question or dependency on that entity. Propose the full Blockers entry for confirmation before writing.
+
+- The agent offers once per item, does not write without confirmation.
+- If the member cannot identify the entity, the agent may search `backlog/` or `requests/` by keyword and propose the best match for confirmation.
 - Assigned items already in context are matched directly without a search.
+- General notes use format: `- YYYY-MM-DD - [Member Name] via standup: [note text]`
 
 ### Scope of Agent Assistance
 

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/adt-event-mapping/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/adt-event-mapping/workitem.md
@@ -25,3 +25,7 @@ Depends on: FHIR Resource Parser
 ## Items this depends on
 
 FHIR Resource Parser must be complete before mapping can be validated.
+
+## Context Log
+
+- 2026-04-01 - Marcus Chen via standup: Discovered FHIR R4 cancelled encounters (status=cancelled) are dropped by current ADT mapper rather than passed through with a flag. Needs handling before validation suite can pass.

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/streaming-ingestion/workitems/schema-registry-integration/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/streaming-ingestion/workitems/schema-registry-integration/workitem.md
@@ -25,3 +25,7 @@ Related to: Kafka Consumer Framework
 ## Items this depends on
 
 Kafka Consumer Framework.
+
+## Context Log
+
+- 2026-04-03 - Leo Kim via standup: Architecture decision — using Confluent Schema Registry over AWS Glue. Rationale: lower ops overhead at current scale given existing Kafka infrastructure. Dana recommended; Marcus to confirm technical approach.

--- a/Example/team/members/leo-kim/discuss-today.md
+++ b/Example/team/members/leo-kim/discuss-today.md
@@ -13,4 +13,4 @@ Soft blocker: waiting on Marcus's review. Not urgent — he committed to looking
 - Marcus: schema registry approach doc is in your inbox — Confluent recommendation is Dana-approved, just need your thumbs up on the technical detail.
 
 ## Notes
-Agent flagged that the Confluent vs. AWS Glue architectural decision is worth capturing on the schema-registry-integration work item for future reference. Added note: `- 2026-04-03 [standup]: Architecture decision — using Confluent Schema Registry over AWS Glue. Rationale: lower ops overhead at current scale given existing Kafka infra. Dana recommended, Marcus to confirm.`
+Agent flagged that the Confluent vs. AWS Glue architectural decision is worth capturing on the schema-registry-integration work item for future reference. Added note: `- 2026-04-03 - Leo Kim via standup: Architecture decision — using Confluent Schema Registry over AWS Glue. Rationale: lower ops overhead at current scale given existing Kafka infra. Dana recommended, Marcus to confirm.`

--- a/Example/team/members/marcus-chen/discuss-log/2026-04-01.md
+++ b/Example/team/members/marcus-chen/discuss-log/2026-04-01.md
@@ -14,4 +14,4 @@ None yet, but the Epic sandbox data request will become a blocker soon if IT doe
 - Dana: quick sync on lineage model when you're ready — want to make sure FHIR resource shape is accounted for.
 
 ## Resolved in Standup
-- Agent confirmed the cancelled encounter edge case warrants a note on the adt-event-mapping work item. Note added: `- 2026-04-01 [standup]: Discovered FHIR R4 cancelled encounters (status=cancelled) are dropped by current ADT mapper rather than passed through with a flag. Needs handling before validation suite can pass.`
+- Agent confirmed the cancelled encounter edge case warrants a note on the adt-event-mapping work item. Note added: `- 2026-04-01 - Marcus Chen via standup: Discovered FHIR R4 cancelled encounters (status=cancelled) are dropped by current ADT mapper rather than passed through with a flag. Needs handling before validation suite can pass.`

--- a/Example/team/standup/example-conversation.md
+++ b/Example/team/standup/example-conversation.md
@@ -92,7 +92,7 @@ This document shows what a `/standup-discussion` session looks like in practice.
 
 **Agent:** Here's what I'll append to the work item:
 
-> `- 2026-04-03 [standup]: Architecture decision — using Confluent Schema Registry over AWS Glue. Rationale: lower ops overhead at current scale given existing Kafka infrastructure. Dana recommended; Marcus to confirm technical approach.`
+> `- 2026-04-03 - Leo Kim via standup: Architecture decision — using Confluent Schema Registry over AWS Glue. Rationale: lower ops overhead at current scale given existing Kafka infrastructure. Dana recommended; Marcus to confirm technical approach.`
 
 Does that capture it accurately?
 

--- a/Fabric/.claude/commands/standup-discussion.md
+++ b/Fabric/.claude/commands/standup-discussion.md
@@ -106,7 +106,7 @@ For each candidate item, offer once:
 - If the item is in context (assigned items): match directly and propose the specific item.
 - If the member names an item: locate it by keyword search in `backlog/` and confirm before writing.
 - If the member asks the agent to find it: search by keyword, propose the best match, confirm before writing.
-- Notes are appended to a `## Notes` section on the entity (`- YYYY-MM-DD [standup]: [note]`). Create the section if absent.
+- General discovery/risk/context notes are appended to the entity's `## Context Log` (`- YYYY-MM-DD - [Member Name] via standup: [note]`). Create the section if absent. Blockers, open questions, and decisions route to their canonical sections per the routing table in `fabric-standup.md`.
 - Do not change status, priority, or any other field — notes only.
 - Do not write without explicit confirmation.
 

--- a/Fabric/backlog/template-inbox-item.md
+++ b/Fabric/backlog/template-inbox-item.md
@@ -7,7 +7,3 @@
 ## Suggested Level
 
 [optional — Epic | Feature | Work Item | Unknown]
-
-## Notes
-
-[optional — any additional context, links, or conversation references that informed this item]

--- a/Fabric/template/fabric-standup.md
+++ b/Fabric/template/fabric-standup.md
@@ -97,14 +97,14 @@ During standup, a member may mention something worth capturing on a backlog item
 | Blocker ("I'm blocked on X", "can't proceed until Y") | `## Blockers` entry + set `Blocked: Yes` in Properties |
 | Open question ("we need to figure out X", "TBD") | `## Open Questions` checkbox item |
 | Decision made ("we decided to...", "going with X") | `## Decisions` entry |
-| General discovery, risk, or context | `## Notes` append |
+| General discovery, risk, or context | `## Context Log` entry |
 
 For blockers specifically: ask who flagged it (defaults to the standup member), what the cause is (open question, dependency, external, other), and whether it relates to an existing open question or dependency on that entity. Propose the full Blockers entry for confirmation before writing.
 
 - The agent offers once per item, does not write without confirmation.
 - If the member cannot identify the entity, the agent may search `backlog/` or `requests/` by keyword and propose the best match for confirmation.
 - Assigned items already in context are matched directly without a search.
-- General notes use format: `- YYYY-MM-DD [standup]: [note text]`
+- General notes use format: `- YYYY-MM-DD - [Member Name] via standup: [note text]`
 
 ### Scope of Agent Assistance
 


### PR DESCRIPTION
## Summary

- Routes standup general discovery/risk/context notes to `## Context Log` on backlog entities instead of a parallel `## Notes` section
- Updates note format to `YYYY-MM-DD - [Member Name] via standup: [text]` for consistency with the Context Log entry standard
- Removes `## Notes` from `template-inbox-item.md` (the only backlog template that carried it)
- Syncs `Example/` standup records, example-conversation, and two affected workitems to the new format

Closes #12

## Test plan

- [ ] Verify `fabric-standup.md` routing table shows `## Context Log` for general discovery/risk/context
- [ ] Verify note format in `fabric-standup.md` and `standup-discussion.md` command matches `YYYY-MM-DD - [Member Name] via standup:`
- [ ] Verify `template-inbox-item.md` no longer has `## Notes`
- [ ] Verify Example workitems have `## Context Log` with correctly formatted standup entries
- [ ] Verify Example standup records reference the new note format