### PR TITLE
Transition UX: meta mode carve-outs, proactive rollup, worklog commits

### DIFF
--- a/Example/.claude/fabric-backlog.md
+++ b/Example/.claude/fabric-backlog.md
@@ -68,6 +68,7 @@ Properties:
 - State: New | Active | Resolved | Removed | Closed
 - External URL: [optional link to an external representation such as ADO url]
 - Repository: [optional — git remote URL of the working repository for this engagement, e.g. https://github.com/org/repo]
+- Repository Path: [optional — subfolder within the repository where this epic's work lives, relative to repo root without a leading slash, e.g. initiatives/project-name]
 - Start Date: [optional]
 - Target Date: [optional]
 - Duration: [optional]
@@ -320,7 +321,7 @@ A match is confident when the agent would naturally reach for the template given
 - When writing a label value, validate it against the team's label schema in CLAUDE.md. If the value is not listed, flag it and suggest the nearest valid option before writing. If no schema is defined, accept any key=value pair.
 - After writing or updating a description or acceptance criteria, cross-reference the content against the label schema descriptions and proactively offer label suggestions. One suggestion per key, only when confident.
 - `Size:` is a relative estimate for backlog prioritization. Do not infer or suggest values — only set it when the user provides one.
-- When an epic has `Repository:` set, the repo is expected as a sibling folder next to the Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). When the user asks about implementation status, code structure, recent commits, or technical details for that epic, check whether the sibling folder exists and read from it on request. Do not read the repo proactively on every query. If the folder is absent, surface this clearly: "This epic has a linked repository (github.com/org/repo) but it isn't cloned locally."
+- When an epic has `Repository:` set, the repo is expected as a sibling folder next to the Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). When the user asks about implementation status, code structure, recent commits, or technical details for that epic, check whether the sibling folder exists and read from it on request. Do not read the repo proactively on every query. If the folder is absent, surface this clearly: "This epic has a linked repository (github.com/org/repo) but it isn't cloned locally." When `Repository Path:` is also set, scope all repo reads to `<sibling-folder>/<repository-path>` and filter git log operations with `-- <repository-path>` to limit commits to those touching that path.
 
 Classification, inbox refinement, assignment recommendations, and reclassification guidance are in the backlog-refinement skill.
 
@@ -379,7 +380,7 @@ When promoting a request to an epic:
 1. **Create the epic** under `backlog/epics/` using the epic template.
 2. **Carry forward** the request's description as the epic's description. It can be refined later during backlog breakdown.
 3. **Carry forward the External URL** if the request already has one (e.g. an ADO epic link). The backlog epic inherits this link.
-4. **Carry forward the Repository** if the request has a `Repository:` field. Copy the value verbatim to the epic's `Repository:` property.
+4. **Carry forward the Repository** if the request has a `Repository:` field. Copy the value verbatim to the epic's `Repository:` property. If the request also has a `Repository Path:` field, carry that forward as well.
 5. **Carry forward Labels** if the request has a `Labels:` field. Copy the value verbatim to the epic's `Labels:` property. Validate each label value against the backlog label schema; flag any mismatches and offer to reconcile before writing.
 6. **Link back to the request** in the epic's Related Items section (e.g. "Originated from request R-044").
 7. **Write the cross-reference back to the request.** Add or update the `Backlog Epic:` field in the request's header to point to the new epic ID. Include this in the confirmation proposal in step 9.
@@ -395,7 +396,7 @@ Use this path when the request is feature-scale — it fits within an existing e
 1. **Scan `backlog/epics/` for Active epics** and present the list to the user. This is proactive — surface what already exists so the user can place the feature correctly and avoid creating unnecessary epics. If the user indicates that none of the existing epics are appropriate, suggest the epic promotion path instead.
 2. **User selects the parent epic.**
 3. **Carry forward** the request's description as the feature's description. It can be refined later.
-4. **Carry forward the External URL**, **Repository**, and **Labels** from the request using the same rules as epic promotion above.
+4. **Carry forward the External URL**, **Repository**, **Repository Path**, and **Labels** from the request using the same rules as epic promotion above.
 5. **Link back to the request** in the feature's Related Items section (e.g. "Originated from request R-044").
 6. **Write the cross-reference back to the request.** Add or update the `Backlog Feature:` field in the request's header to point to the new feature ID. Include this in the confirmation proposal in step 8.
 7. **Do not change the request's triage state.**

--- a/Example/.claude/fabric-backlog.md
+++ b/Example/.claude/fabric-backlog.md
@@ -311,7 +311,7 @@ A match is confident when the agent would naturally reach for the template given
 - The statuses, types, and scoping definitions above are defaults. Teams can override any of these in the "How We Work" section of their constitution (CLAUDE.md). When custom values are defined there, use those instead of the defaults.
 - When creating any backlog entity (epic, feature, work item, task), generate an ID following the convention in the Entity IDs section above (or the team's custom convention if defined). Propose the generated ID to the user before writing so it can be adjusted.
 - When creating a backlog entity, check `backlog/templates/` for applicable team templates before drafting. See the Team Templates section for matching, suggestion, and application rules.
-- Backlog entities are structural and protected by meta mode.
+- Backlog entity **structure** is protected by meta mode: removing, renaming, or re-scoping epics and features requires meta mode. Creating new backlog entities, state transitions on features, and Child Summary section updates are **not** structural — they do not require meta mode, consistent with how `/transition` already treats work items.
 - When creating a new feature, check if it should reference an existing product (if Product module is enabled).
 - Status rollup: when all child entities are complete, suggest updating the parent's status.
 - Do not create backlog entities autonomously. Propose the entity and wait for confirmation.

--- a/Example/.claude/fabric-standup.md
+++ b/Example/.claude/fabric-standup.md
@@ -49,7 +49,7 @@ team/standup/
 
 | Skill | Description |
 |-------|-------------|
-| `standup-context` | Enriches standup context: loads assigned work, scans product repos for contributions, reads team standup for follow-up items. Invoked by `/standup-discussion` before conversation begins. |
+| `standup-context` | Enriches standup context: loads assigned work, scans engagement and product repos for contributions, runs assignment hygiene checks, reads team standup for follow-up items. Invoked by `/standup-discussion` before conversation begins. |
 | `standup-report` | Reads all members' standup records, produces a team-wide summary with sync opportunities and breakout suggestions. Handles team-level rollover on generation. Add `weekly` to aggregate across multiple check-ins within the current week — supplemental for teams with 2+ standups per week. |
 
 ## Behavioral Rules
@@ -138,6 +138,24 @@ Same discipline as the note pass: offer once per item, do not create without exp
 ### Post-Standup Action Checklist
 
 After the standup record is written, the agent produces a short markdown checkbox list of items the member still needs to act on: deferred or declined backlog gaps from the untracked work scan, follow-up actions surfaced during the conversation, and manual backlog updates the member indicated they'd handle themselves. The checklist is omitted entirely if there are no outstanding items.
+
+### Engagement Repository Detection
+
+The `standup-context` skill checks each directly assigned epic and request for a `Repository:` field. For each one found, it resolves the local clone using the sibling-directory convention (last path segment of the URL, relative to the Fabric instance root) and runs `git log --author --since` to detect commits since the member's last standup. Results appear in the context bundle as `engagement_contributions` and are surfaced in the conversation alongside product contributions.
+
+This addresses the common pattern where initiative work lives in per-engagement repositories that are not registered as products. Without this check, a member actively committing to an engagement repo would appear to have no contributions.
+
+### Assignment Hygiene Check
+
+After loading assigned items, the `standup-context` skill scans for three gap types and surfaces them as specific questions during the conversation:
+
+| Gap type | Signal | Suggested question style |
+|----------|--------|--------------------------|
+| `context_log_stale` | Most recent `## Context Log` entry predates last team standup | "Anything worth capturing on [Entity] from the past week?" |
+| `repository_gap` | `Repository:` is set but no commits found for this member since last standup | "I didn't see commits in [repo] — is that paused, or happening elsewhere?" |
+| `state_lag` | Prior standup described item as complete, but `State:` is still Active or New | "Last standup you said [Entity] was wrapping up — still Active, did you want to transition it?" |
+
+Hygiene gaps are surfaced once per item, conversationally, and only if the member's answers haven't already resolved them.
 
 ### Scope of Agent Assistance
 

--- a/Example/.claude/fabric-triage.md
+++ b/Example/.claude/fabric-triage.md
@@ -55,15 +55,23 @@ requests/
 
 ### Repository Linking on Requests
 
-Requests support an optional `Repository:` field in their Properties section. This is the git remote URL of the working repository for the engagement — where the team's implementation work lives. It is a work repository, not a product entity.
+Requests support optional `Repository:` and `Repository Path:` fields in their Properties section. `Repository:` is the git remote URL of the working repository for the engagement — where the team's implementation work lives. It is a work repository, not a product entity. `Repository Path:` scopes context operations to a subfolder within that repository, which is useful when the team works in a monorepo or shared repository.
 
 ```
-Repository: https://github.com/org/sepsis-model
+Repository: https://github.com/org/shared-repo
+Repository Path: initiatives/project-name
 ```
+
+`Repository Path:` is relative to the repository root and stored without a leading slash. When absent, all context operations apply to the full repository root.
 
 **Lookup convention:** The repo is expected as a sibling folder next to this Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). Teams are responsible for keeping that clone present.
 
 **Context surfacing:** When a request has `Repository:` set and someone asks about the request, check whether the sibling folder exists. If it does, the agent may read from it on request — recent commits, file structure, open issues — to provide relevant context. Do not read the repo proactively on every query; surface it when the user asks about implementation status, technical details, or code context for the request.
+
+When `Repository Path:` is set, scope all repo reads to `<sibling-folder>/<repository-path>`. For git log operations, append `-- <repository-path>` to limit commits to those touching that path:
+```
+git log --author=<email> --since=<date> --oneline -- <repository-path>
+```
 
 If the sibling folder is absent, note this clearly rather than failing silently:
 > "R-NNN has a linked repository (github.com/org/sepsis-model) but it isn't cloned locally. Clone it as a sibling folder to access code context."

--- a/Example/requests/workflow/default/request-template.md
+++ b/Example/requests/workflow/default/request-template.md
@@ -19,6 +19,7 @@ Effort: [hours of planning/discovery work invested in this request — populated
 Engagement Model: [Not Set | Full-Service | Collaborative | Advisory]
 External: [None | e.g., ADO Epic #1234 — https://dev.azure.com/org/project/_workitems/edit/1234]
 Repository: [optional — git remote URL of the working repository for this engagement, e.g. https://github.com/org/repo]
+Repository Path: [optional — subfolder within the repository where this engagement's work lives, relative to repo root without a leading slash, e.g. initiatives/project-name]
 Labels: [optional, comma-separated key=value pairs matching the team's label schema, e.g. service-type=data-extraction]
 
 ### Requestor Details

--- a/Fabric/.claude/commands/rollup-backlog.md
+++ b/Fabric/.claude/commands/rollup-backlog.md
@@ -65,5 +65,5 @@ Regenerate Child Summary sections on epics and features to reflect current child
 
 ## Notes
 
-- Requires meta mode (modifies structural entity files).
+- Does not require meta mode. Child Summary sections are auto-maintained computed output, not structural decisions. (Structural mutations on epics and features — remove, rename, rescope — still require meta mode.)
 - The rollup logic is implemented in the entity-maintenance skill. This command handles target resolution, scan orchestration, and the `--deep` flag.

--- a/Fabric/.claude/commands/standup-discussion.md
+++ b/Fabric/.claude/commands/standup-discussion.md
@@ -54,11 +54,29 @@ If the `standup-context` skill found mentions of this member in the prior team s
 
 > "In the last team standup, [Name] had a question for you about [X] — were you able to connect? Any update there?"
 
+**Engagement contributions** *(if detected)*
+
+If the context skill found git commits in an engagement repo (from an assigned epic or request) since their last standup, surface them the same way as product contributions:
+
+> "It looks like you've been committing to [repo] for [Entity] — want to include that in yesterday's summary?"
+
 **Product contributions** *(if detected)*
 
 If the context skill found git commits in a product repo since their last standup, surface them naturally:
 
 > "It looks like you contributed to [Product] — want to include what you did there in yesterday's summary?"
+
+**Hygiene gaps** *(if any were found in context)*
+
+After contributions, surface hygiene gaps as specific, named questions woven into the conversation — not as a list or reminder. Use the `suggested_question` from the context bundle as the basis. One question per gap, asked once only.
+
+Examples by gap type:
+
+- *Context log stale*: "Your [Entity Name] hasn't had a context log entry since [date] — anything worth capturing there from the past week?"
+- *Repository gap*: "[Entity Name] has [repo] linked, but I didn't find any commits from you there since your last standup. Is that work happening in a different branch or repo, or has it been paused?"
+- *State lag*: "Last standup you mentioned [Entity Name] was wrapping up — it's still showing Active. Did you want to transition it, or is there more work left?"
+
+Do not surface gaps that are clearly explained by what the member has already said in the conversation.
 
 **Yesterday** — What did they work on? Reference specific assigned items and any contributions from context. Ask how it went, not just what they did.
 

--- a/Fabric/.claude/commands/transition.md
+++ b/Fabric/.claude/commands/transition.md
@@ -37,6 +37,6 @@
 
 ## Notes
 
-- Read-only until confirmation. No meta mode required for state changes on non-structural entities.
+- Read-only until confirmation. No meta mode required for state changes on work items, tasks, features, or epics. Meta mode is only required for structural mutations: removing, renaming, or re-scoping epics and features.
 - The transition skill is also invoked implicitly when the agent detects state-change intent in conversation — this command is the explicit path.
 - Resolved, Closed, and Removed entities are never deleted. Physical cleanup is deferred to the garbage collection process.

--- a/Fabric/.claude/commands/update-fabric.md
+++ b/Fabric/.claude/commands/update-fabric.md
@@ -68,8 +68,10 @@ For each recommendation, briefly explain the new capability and what the team co
 
 ### Stakeholder Profiles
 
-Check if `team/team.md` has a `## Stakeholders` table with entries AND `team/stakeholders/` either doesn't exist or has no profile directories.
+1. Read `team/team.md` and collect every stakeholder name from the `## Stakeholders` table.
+2. For each name, check whether `team/stakeholders/<name>/profile.md` exists.
+3. Build a list of names that have no profile file.
 
-If so, suggest: "Stakeholder profile directories are now supported at `team/stakeholders/<name>/profile.md`. For stakeholders who are closely engaged with your team, a profile can capture communication preferences, areas of expertise, and an ingestion context log. Based on your current stakeholders table, candidates worth considering: [list names from the table]. You can create profiles via `/meta`."
+If there are any stakeholders without profiles, suggest: "Stakeholder profile directories are now supported at `team/stakeholders/<name>/profile.md`. For stakeholders who are closely engaged with your team, a profile can capture communication preferences, areas of expertise, and an ingestion context log. The following stakeholders do not yet have profiles: [list only the missing names]. You can create profiles via `/meta`."
 
-If `team/stakeholders/` already has profiles, no recommendation needed.
+If every stakeholder already has a profile, or if the `## Stakeholders` table is absent or empty, output nothing for this section.

--- a/Fabric/.claude/skills/entity-transitions.md
+++ b/Fabric/.claude/skills/entity-transitions.md
@@ -190,3 +190,26 @@ When invoked implicitly, identify the target entity and desired state from conte
 - Be direct about issues but not alarmist. A warning is informational; the user decides whether to proceed.
 - Do not repeat the same concern multiple times in the same transition.
 - Keep confirmation prompts short. The user has already seen the findings.
+
+---
+
+## Post-Transition Commit Offer
+
+After all cascade steps are resolved and any rollup offer has been handled, offer to commit the Fabric state changes:
+
+```
+Transition complete. Commit?
+  worklog: [verb] [entity-type] [entity-slug]
+  e.g. worklog: close feature fhir-r4-parser-260315
+       worklog: activate work-item adt-event-mapping
+       worklog: remove epic ehr-pipeline-modernization
+
+Commit with this message? (yes / edit / skip)
+```
+
+- **verb**: `activate`, `resolve`, `close`, or `remove` — matching the transition taken.
+- **entity-type**: `epic`, `feature`, `work-item`, or `task` — singular, hyphenated.
+- **entity-slug**: the folder name (slug) of the entity.
+- If the user chooses "edit", show the proposed message and let them revise it, then commit.
+- After committing, ask: "Push to remote? (yes / no)"
+- Stage only the files changed during this transition: the entity file, any cascaded files, and any rolled-up parent. Do not stage unrelated changes.

--- a/Fabric/.claude/skills/entity-transitions.md
+++ b/Fabric/.claude/skills/entity-transitions.md
@@ -96,7 +96,20 @@ When invoked implicitly, identify the target entity and desired state from conte
 
 9. On confirmation: set `State: Resolved` or `State: Closed` as appropriate for the entity type. Update any confirmed explicit DoD checkboxes. Write `Terminated: <today's date>` to the Properties block if not already set.
 
-10. **Cascade scan** (after writing state change): scan for entities that reference this entity and may need updating. Work through each category in order; skip any with no results.
+10. **Rollup offer** (work items and features only — not epics): after writing the state change, identify the immediate parent entity. Offer to refresh its Child Summary:
+    ```
+    [Entity Title] is now [Resolved/Closed]. The parent [Feature/Epic] '[Parent Title]' has a stale Child Summary.
+    Refresh the Child Summary now? (yes / no)
+    ```
+    If yes: run the rollup logic for the parent inline (same behavior as `/rollup-backlog [parent]`). Propose the updated Child Summary section, then write on confirmation.
+
+    After the rollup (or if the user declines), check whether **all** direct children of the parent are now in a terminal state (Closed, Resolved, or Removed). If so, surface the parent as a transition candidate:
+    ```
+    All children of '[Parent Title]' are now complete. Would you like to close it too? (yes / no)
+    ```
+    If yes: invoke this same transition path for the parent.
+
+11. **Cascade scan** (after writing state change): scan for entities that reference this entity and may need updating. Work through each category in order; skip any with no results.
 
     a. **Dependency cascade**: search all entity files for `## Items this depends on` sections referencing this entity (match by ID or title). For each found:
        - Propose removing the dependency entry (the work is done — the dependency is resolved).

--- a/Fabric/.claude/skills/standup-context.md
+++ b/Fabric/.claude/skills/standup-context.md
@@ -36,6 +36,7 @@ Read `products/` to identify products this member is active on. For each product
 1. Check the product's `product.md` for a `Repo:` field containing a local path or a remote URL that resolves to a local clone.
 2. If a discoverable repo path exists and is accessible:
    - Run: `git log --author=<member-email> --since=<last-standup-date> --oneline`
+   - If the product or a linked entity has a `Repository Path:` set, append `-- <repository-path>` to scope the log to commits touching that path only.
    - Use the date from `discuss-yesterday.md` as `--since`. If no prior standup exists, use 2 days ago as a fallback.
    - If commits are found, record the product name and a brief summary of the commits (message lines only — do not read diffs).
 3. If no `Repo:` field or the path is not accessible, skip silently.

--- a/Fabric/.claude/skills/standup-context.md
+++ b/Fabric/.claude/skills/standup-context.md
@@ -25,9 +25,21 @@ If the file does not exist, note that this may be the member's first standup.
 
 ### 3. Load Assigned Backlog Items
 
-Scan backlog entities for items with `Assigned to:` matching this member's name. Limit to Active and In Progress states. Load work items and tasks only — do not load epics or features unless they are directly assigned.
+Scan backlog entities for items with `Assigned to:` matching this member's name. Limit to Active and In Progress states. Load work items and tasks; also load epics and requests that are directly assigned to this member — they may carry `Repository:` fields needed for Step 3b.
 
 Do not load the full backlog tree. Search by scanning entity files for the `Assigned to:` field. Stop at a reasonable depth — if the backlog is large, note that results may be partial.
+
+### 3b. Detect Engagement Repository Contributions
+
+For each assigned epic or request that has a `Repository:` field:
+
+1. Resolve the local clone path: infer the folder name from the last path segment of the `Repository:` URL (e.g. `https://github.com/org/project-alpha` → `../project-alpha` relative to the Fabric instance root). This follows the same sibling-directory convention as Knowledge Repository path resolution in `fabric-core.md`.
+2. If the folder exists and is a git repository:
+   - Run: `git log --author=<member-email> --since=<last-standup-date> --oneline`
+   - If the entity has a `Repository Path:` field, append `-- <repository-path>` to scope the log to commits touching that subfolder only.
+   - Use the date from `discuss-yesterday.md` as `--since`. If no prior standup exists, use 2 days ago as a fallback.
+   - If commits are found, record the entity name, repo URL, and a brief summary of the commits (message lines only — do not read diffs).
+3. If the folder is not found or not accessible, skip silently.
 
 ### 4. Detect Product Contributions
 
@@ -41,7 +53,19 @@ Read `products/` to identify products this member is active on. For each product
    - If commits are found, record the product name and a brief summary of the commits (message lines only — do not read diffs).
 3. If no `Repo:` field or the path is not accessible, skip silently.
 
-### 5. Check Team Standup for Follow-Ups
+### 5. Assignment Hygiene Check
+
+For each item in `assigned_items`, scan for the following gaps. Use the last team standup date (from `team/standup/standup-yesterday.md` header, if it exists) as the reference point.
+
+**Context log stale** — Find the most recent `- YYYY-MM-DD` date entry in the entity's `## Context Log`. If that date predates the last team standup date, flag it. If no context log exists and the item has been Active for more than one standup cycle, flag it. Include the entity name and the most recent log date (or "no entries").
+
+**Repository gap** — The entity has a `Repository:` field, but Step 3b found no commits from this member in that repo since the last standup. Flag it with the entity name and repo URL.
+
+**State lag** — Scan `discuss-yesterday.md` for language that signals completion of this entity ("finished", "wrapped up", "done with", "completed", "closed out", followed by the entity name or a close synonym). If found, and the entity's `State:` is still Active or New, flag it with the entity name and the relevant phrase from the prior standup.
+
+Collect all gaps into a `hygiene_gaps` list. Each entry has: entity name, gap type, and a suggested question the conversation can use to probe it.
+
+### 6. Check Team Standup for Follow-Ups
 
 Read `team/standup/standup-yesterday.md` if it exists.
 
@@ -67,9 +91,19 @@ prior_standup:
 assigned_items:
   - [item name, state, entity type]
 
+engagement_contributions:
+  - entity: [epic or request name]
+    repo: [Repository: URL]
+    commits: [one-line summaries]
+
 product_contributions:
   - product: [name]
     commits: [one-line summaries]
+
+hygiene_gaps:
+  - entity: [item name]
+    gap_type: context_log_stale | repository_gap | state_lag
+    suggested_question: [specific question to raise in conversation]
 
 team_followups:
   - from: [other member name]

--- a/Fabric/backlog/template-epic.md
+++ b/Fabric/backlog/template-epic.md
@@ -7,6 +7,7 @@
 - Blocked: [optional — Yes | No; if Yes, see ## Blockers for details. Cleared when all blocker entries are resolved.]
 - External URL: [optional link to an external representation of this epic such as ADO url]
 - Repository: [optional — git remote URL of the working repository for this engagement, e.g. https://github.com/org/repo]
+- Repository Path: [optional — subfolder within the repository where this epic's work lives, relative to repo root without a leading slash, e.g. initiatives/project-name]
 - Start Date: [optional date (e.g. 2026-05-01) we want to start work on the epic]
 - Target Date: [optional date (e.g. 2027-01-01) we want to deliver the epic]
 - Duration: [optional, how long the epic is estimated to take once started]

--- a/Fabric/requests/workflow/default/request-template.md
+++ b/Fabric/requests/workflow/default/request-template.md
@@ -18,6 +18,7 @@ Effort Estimate: [Not Set | Small (< 1 week) | Medium (1-4 weeks) | Large (> 1 m
 Effort: [hours of planning/discovery work invested in this request — populated on close]
 External: [None | e.g., ADO Epic #1234 — https://dev.azure.com/org/project/_workitems/edit/1234]
 Repository: [optional — git remote URL of the working repository for this engagement]
+Repository Path: [optional — subfolder within the repository where this engagement's work lives, relative to repo root without a leading slash, e.g. initiatives/project-name]
 Labels: [optional, comma-separated key=value pairs matching the team's label schema]
 
 ### Requestor Details

--- a/Fabric/template/fabric-backlog.md
+++ b/Fabric/template/fabric-backlog.md
@@ -68,6 +68,7 @@ Properties:
 - State: New | Active | Resolved | Removed | Closed
 - External URL: [optional link to an external representation such as ADO url]
 - Repository: [optional — git remote URL of the working repository for this engagement, e.g. https://github.com/org/repo]
+- Repository Path: [optional — subfolder within the repository where this epic's work lives, relative to repo root without a leading slash, e.g. initiatives/project-name]
 - Start Date: [optional]
 - Target Date: [optional]
 - Duration: [optional]
@@ -320,7 +321,7 @@ A match is confident when the agent would naturally reach for the template given
 - When writing a label value, validate it against the team's label schema in CLAUDE.md. If the value is not listed, flag it and suggest the nearest valid option before writing. If no schema is defined, accept any key=value pair.
 - After writing or updating a description or acceptance criteria, cross-reference the content against the label schema descriptions and proactively offer label suggestions. One suggestion per key, only when confident.
 - `Size:` is a relative estimate for backlog prioritization. Do not infer or suggest values — only set it when the user provides one.
-- When an epic has `Repository:` set, the repo is expected as a sibling folder next to the Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). When the user asks about implementation status, code structure, recent commits, or technical details for that epic, check whether the sibling folder exists and read from it on request. Do not read the repo proactively on every query. If the folder is absent, surface this clearly: "This epic has a linked repository (github.com/org/repo) but it isn't cloned locally."
+- When an epic has `Repository:` set, the repo is expected as a sibling folder next to the Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). When the user asks about implementation status, code structure, recent commits, or technical details for that epic, check whether the sibling folder exists and read from it on request. Do not read the repo proactively on every query. If the folder is absent, surface this clearly: "This epic has a linked repository (github.com/org/repo) but it isn't cloned locally." When `Repository Path:` is also set, scope all repo reads to `<sibling-folder>/<repository-path>` and filter git log operations with `-- <repository-path>` to limit commits to those touching that path.
 
 Classification, inbox refinement, assignment recommendations, and reclassification guidance are in the backlog-refinement skill.
 
@@ -379,7 +380,7 @@ When promoting a request to an epic:
 1. **Create the epic** under `backlog/epics/` using the epic template.
 2. **Carry forward** the request's description as the epic's description. It can be refined later during backlog breakdown.
 3. **Carry forward the External URL** if the request already has one (e.g. an ADO epic link). The backlog epic inherits this link.
-4. **Carry forward the Repository** if the request has a `Repository:` field. Copy the value verbatim to the epic's `Repository:` property.
+4. **Carry forward the Repository** if the request has a `Repository:` field. Copy the value verbatim to the epic's `Repository:` property. If the request also has a `Repository Path:` field, carry that forward as well.
 5. **Carry forward Labels** if the request has a `Labels:` field. Copy the value verbatim to the epic's `Labels:` property. Validate each label value against the backlog label schema; flag any mismatches and offer to reconcile before writing.
 6. **Link back to the request** in the epic's Related Items section (e.g. "Originated from request R-044").
 7. **Write the cross-reference back to the request.** Add or update the `Backlog Epic:` field in the request's header to point to the new epic ID. Include this in the confirmation proposal in step 9.
@@ -395,7 +396,7 @@ Use this path when the request is feature-scale — it fits within an existing e
 1. **Scan `backlog/epics/` for Active epics** and present the list to the user. This is proactive — surface what already exists so the user can place the feature correctly and avoid creating unnecessary epics. If the user indicates that none of the existing epics are appropriate, suggest the epic promotion path instead.
 2. **User selects the parent epic.**
 3. **Carry forward** the request's description as the feature's description. It can be refined later.
-4. **Carry forward the External URL**, **Repository**, and **Labels** from the request using the same rules as epic promotion above.
+4. **Carry forward the External URL**, **Repository**, **Repository Path**, and **Labels** from the request using the same rules as epic promotion above.
 5. **Link back to the request** in the feature's Related Items section (e.g. "Originated from request R-044").
 6. **Write the cross-reference back to the request.** Add or update the `Backlog Feature:` field in the request's header to point to the new feature ID. Include this in the confirmation proposal in step 8.
 7. **Do not change the request's triage state.**

--- a/Fabric/template/fabric-backlog.md
+++ b/Fabric/template/fabric-backlog.md
@@ -311,7 +311,7 @@ A match is confident when the agent would naturally reach for the template given
 - The statuses, types, and scoping definitions above are defaults. Teams can override any of these in the "How We Work" section of their constitution (CLAUDE.md). When custom values are defined there, use those instead of the defaults.
 - When creating any backlog entity (epic, feature, work item, task), generate an ID following the convention in the Entity IDs section above (or the team's custom convention if defined). Propose the generated ID to the user before writing so it can be adjusted.
 - When creating a backlog entity, check `backlog/templates/` for applicable team templates before drafting. See the Team Templates section for matching, suggestion, and application rules.
-- Backlog entities are structural and protected by meta mode.
+- Backlog entity **structure** is protected by meta mode: removing, renaming, or re-scoping epics and features requires meta mode. Creating new backlog entities, state transitions on features, and Child Summary section updates are **not** structural — they do not require meta mode, consistent with how `/transition` already treats work items.
 - When creating a new feature, check if it should reference an existing product (if Product module is enabled).
 - Status rollup: when all child entities are complete, suggest updating the parent's status.
 - Do not create backlog entities autonomously. Propose the entity and wait for confirmation.

--- a/Fabric/template/fabric-standup.md
+++ b/Fabric/template/fabric-standup.md
@@ -49,7 +49,7 @@ team/standup/
 
 | Skill | Description |
 |-------|-------------|
-| `standup-context` | Enriches standup context: loads assigned work, scans product repos for contributions, reads team standup for follow-up items. Invoked by `/standup-discussion` before conversation begins. |
+| `standup-context` | Enriches standup context: loads assigned work, scans engagement and product repos for contributions, runs assignment hygiene checks, reads team standup for follow-up items. Invoked by `/standup-discussion` before conversation begins. |
 | `standup-report` | Reads all members' standup records, produces a team-wide summary with sync opportunities and breakout suggestions. Handles team-level rollover on generation. Add `weekly` to aggregate across multiple check-ins within the current week — supplemental for teams with 2+ standups per week. |
 
 ## Behavioral Rules
@@ -138,6 +138,24 @@ Same discipline as the note pass: offer once per item, do not create without exp
 ### Post-Standup Action Checklist
 
 After the standup record is written, the agent produces a short markdown checkbox list of items the member still needs to act on: deferred or declined backlog gaps from the untracked work scan, follow-up actions surfaced during the conversation, and manual backlog updates the member indicated they'd handle themselves. The checklist is omitted entirely if there are no outstanding items.
+
+### Engagement Repository Detection
+
+The `standup-context` skill checks each directly assigned epic and request for a `Repository:` field. For each one found, it resolves the local clone using the sibling-directory convention (last path segment of the URL, relative to the Fabric instance root) and runs `git log --author --since` to detect commits since the member's last standup. Results appear in the context bundle as `engagement_contributions` and are surfaced in the conversation alongside product contributions.
+
+This addresses the common pattern where initiative work lives in per-engagement repositories that are not registered as products. Without this check, a member actively committing to an engagement repo would appear to have no contributions.
+
+### Assignment Hygiene Check
+
+After loading assigned items, the `standup-context` skill scans for three gap types and surfaces them as specific questions during the conversation:
+
+| Gap type | Signal | Suggested question style |
+|----------|--------|--------------------------|
+| `context_log_stale` | Most recent `## Context Log` entry predates last team standup | "Anything worth capturing on [Entity] from the past week?" |
+| `repository_gap` | `Repository:` is set but no commits found for this member since last standup | "I didn't see commits in [repo] — is that paused, or happening elsewhere?" |
+| `state_lag` | Prior standup described item as complete, but `State:` is still Active or New | "Last standup you said [Entity] was wrapping up — still Active, did you want to transition it?" |
+
+Hygiene gaps are surfaced once per item, conversationally, and only if the member's answers haven't already resolved them.
 
 ### Scope of Agent Assistance
 

--- a/Fabric/template/fabric-triage.md
+++ b/Fabric/template/fabric-triage.md
@@ -55,15 +55,23 @@ requests/
 
 ### Repository Linking on Requests
 
-Requests support an optional `Repository:` field in their Properties section. This is the git remote URL of the working repository for the engagement — where the team's implementation work lives. It is a work repository, not a product entity.
+Requests support optional `Repository:` and `Repository Path:` fields in their Properties section. `Repository:` is the git remote URL of the working repository for the engagement — where the team's implementation work lives. It is a work repository, not a product entity. `Repository Path:` scopes context operations to a subfolder within that repository, which is useful when the team works in a monorepo or shared repository.
 
 ```
-Repository: https://github.com/org/sepsis-model
+Repository: https://github.com/org/shared-repo
+Repository Path: initiatives/project-name
 ```
+
+`Repository Path:` is relative to the repository root and stored without a leading slash. When absent, all context operations apply to the full repository root.
 
 **Lookup convention:** The repo is expected as a sibling folder next to this Fabric instance, named after the repository slug (e.g. `https://github.com/org/sepsis-model` → `../sepsis-model`). Teams are responsible for keeping that clone present.
 
 **Context surfacing:** When a request has `Repository:` set and someone asks about the request, check whether the sibling folder exists. If it does, the agent may read from it on request — recent commits, file structure, open issues — to provide relevant context. Do not read the repo proactively on every query; surface it when the user asks about implementation status, technical details, or code context for the request.
+
+When `Repository Path:` is set, scope all repo reads to `<sibling-folder>/<repository-path>`. For git log operations, append `-- <repository-path>` to limit commits to those touching that path:
+```
+git log --author=<email> --since=<date> --oneline -- <repository-path>
+```
 
 If the sibling folder is absent, note this clearly rather than failing silently:
 > "R-NNN has a linked repository (github.com/org/sepsis-model) but it isn't cloned locally. Clone it as a sibling folder to access code context."


### PR DESCRIPTION
- **closes #35** — Two-tier meta mode for backlog: creating entities, feature state transitions, and Child Summary updates no longer require meta mode. Only removing, renaming, or re-scoping epics/features does.
- **closes #36** — After closing a work item or feature, `/transition` now offers to refresh the parent's Child Summary inline; if all siblings are terminal, it surfaces the parent as a close candidate.
- **closes #37** — After every successful transition, the agent offers a `worklog:`-prefixed commit (e.g. `worklog: close feature fhir-r4-parser-260315`) with an optional push, keeping backlog activity visually distinct in git history.
- `Fabric/template/fabric-backlog.md` + `Example/.claude/fabric-backlog.md` — updated meta mode rule
- `Fabric/.claude/commands/rollup-backlog.md` — removed "Requires meta mode" note
- `Fabric/.claude/commands/transition.md` — explicit carve-out note covering all entity types
- `Fabric/.claude/skills/entity-transitions.md` — new step 10 (rollup offer) and Post-Transition Commit Offer section
- [ ] Run `/transition` on a work item → confirm rollup offer appears for parent feature
- [ ] Decline rollup → confirm worklog commit offer still appears
- [ ] Close last work item in a feature → confirm parent transition candidate is surfaced
- [ ] Verify creating a new epic/feature proceeds without meta mode prompt
- [ ] Verify removing/renaming an epic still prompts for meta mode