### PR TITLE
Add /personal-backlog command with feature-level assignment support

### DIFF
--- a/Example/.claude/fabric-backlog.md
+++ b/Example/.claude/fabric-backlog.md
@@ -410,6 +410,7 @@ After promotion, the feature is a normal backlog item under its parent epic — 
 |---------|-------------|
 | /refine | Enter a backlog refinement conversation. Accepts an entity target, inbox item, or request ID. |
 | /rollup-backlog | Refresh Child Summary sections on epics and features. |
+| /personal-backlog | Generate a personal work queue for the current user, filtered to the current iteration if configured. |
 
 ## Skills
 

--- a/Example/.claude/fabric-backlog.md
+++ b/Example/.claude/fabric-backlog.md
@@ -94,6 +94,7 @@ Properties:
 - Priority: [optional 1(lowest)-5(highest)]
 - Size: [optional, relative size estimate — any numeric value or ?. Fibonacci sequence (1, 2, 3, 5, 8, 13, 21) is conventional but not enforced. Distinct from Effort and task hour fields.]
 - Area: [optional area path representing a product or service line]
+- Assigned to: [optional — email of the team member primarily responsible for this feature]
 - Effort: [optional, direct hours at the feature level — refinement, design, or coordination work not captured in child work items; also used by teams that track at the feature level without breaking down further]
 - Labels: [optional, comma-separated key=value pairs e.g. service-type=data-extraction]
 

--- a/Example/backlog/epics/ehr-pipeline-modernization/epic.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/epic.md
@@ -22,3 +22,43 @@ Impacts product: Clinical Data Lake
 ## Items this depends on
 
 None currently identified.
+
+## Definition of Done
+
+<!-- Implicit: all child features are Closed, Resolved, or Removed.
+     Add any additional criteria for this epic below (e.g. deployed to production, stakeholder sign-off).
+- [ ] Additional criterion
+-->
+
+## Blockers
+
+<!-- Active and resolved blocks on this entity.
+     Set Blocked: Yes in Properties when any entry is Active; clear it when all are resolved.
+     ### [YYYY-MM-DD] Brief description of the block
+     - **Flagged by:** Name
+     - **Cause:** [Open question / Dependency / External / Other — be specific; reference the open question or dependency by name if applicable]
+     - **Follow-up:** YYYY-MM-DD — [what will happen on that date] (optional — omit if needs immediate attention)
+     - **Status:** Active | Resolved — YYYY-MM-DD ([how it resolved])
+-->
+
+## Open Questions
+
+<!-- Unresolved questions that may be blocking progress.
+     When resolved, check the box and add a Decisions entry below.
+- [ ] Question text *(asked by Name, YYYY-MM-DD)*
+-->
+
+## Decisions
+
+<!-- Structured record of key decisions made on this entity.
+     Agent will propose an entry when decision language is detected during ingestion or conversation.
+     ### [YYYY-MM-DD] Decision title
+     - **Decided by:** Name
+     - **Recorded by:** Name or Claude (ingestion)
+     - **Options considered:** Option A (rejected: reason), Option B (rejected: reason), chosen option
+     - **Rationale:** Why this option was chosen
+-->
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child features and their status.]

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/data-lineage-tracking/feature.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/data-lineage-tracking/feature.md
@@ -29,3 +29,7 @@ Part of epic: EHR Pipeline Modernization
 ## Items this depends on
 
 None — can proceed independently of FHIR and streaming work.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/feature.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/feature.md
@@ -30,3 +30,43 @@ Part of epic: EHR Pipeline Modernization
 ## Items this depends on
 
 None.
+
+## Definition of Done
+
+<!-- Implicit: all child work items are Closed, Resolved, or Removed.
+     Add any additional criteria for this feature below (e.g. deployed to staging, release notes written).
+- [ ] Additional criterion
+-->
+
+## Blockers
+
+<!-- Active and resolved blocks on this entity.
+     Set Blocked: Yes in Properties when any entry is Active; clear it when all are resolved.
+     ### [YYYY-MM-DD] Brief description of the block
+     - **Flagged by:** Name
+     - **Cause:** [Open question / Dependency / External / Other — be specific; reference the open question or dependency by name if applicable]
+     - **Follow-up:** YYYY-MM-DD — [what will happen on that date] (optional — omit if needs immediate attention)
+     - **Status:** Active | Resolved — YYYY-MM-DD ([how it resolved])
+-->
+
+## Open Questions
+
+<!-- Unresolved questions that may be blocking progress.
+     When resolved, check the box and add a Decisions entry below.
+- [ ] Question text *(asked by Name, YYYY-MM-DD)*
+-->
+
+## Decisions
+
+<!-- Structured record of key decisions made on this entity.
+     Agent will propose an entry when decision language is detected during ingestion or conversation.
+     ### [YYYY-MM-DD] Decision title
+     - **Decided by:** Name
+     - **Recorded by:** Name or Claude (ingestion)
+     - **Options considered:** Option A (rejected: reason), Option B (rejected: reason), chosen option
+     - **Rationale:** Why this option was chosen
+-->
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/feature.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/feature.md
@@ -11,6 +11,7 @@
 - Duration: 3.5 months
 - Priority: 4
 - Area: Clinical Data Lake
+- Assigned to: marcus.chen@riverdale.org
 - Labels: service-type=data-extraction, data-domain=clinical, security-sensitive=true
 
 ## Description

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/adt-event-mapping/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/adt-event-mapping/workitem.md
@@ -4,9 +4,9 @@
 
 - State: New
 - Type: Story
-- Iteration: Sprint 2026-09
+- Iteration: 260415-260428
 - External URL:
-- Assigned to:
+- Assigned to: marcus.chen@riverdale.org
 
 ## Description
 

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-resource-parser/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-resource-parser/workitem.md
@@ -25,3 +25,39 @@ None.
 ## Items this depends on
 
 None.
+
+## Definition of Done
+
+<!-- Implicit: all Acceptance Criteria reviewed as met; all child tasks are Closed or Removed.
+     Add any additional criteria for this work item below.
+- [ ] Additional criterion
+-->
+
+## Blockers
+
+<!-- Active and resolved blocks on this entity.
+     Set Blocked: Yes in Properties when any entry is Active; clear it when all are resolved.
+     ### [YYYY-MM-DD] Brief description of the block
+     - **Flagged by:** Name
+     - **Cause:** [Open question / Dependency / External / Other — be specific; reference the open question or dependency by name if applicable]
+     - **Follow-up:** YYYY-MM-DD — [what will happen on that date] (optional — omit if needs immediate attention)
+     - **Status:** Active | Resolved — YYYY-MM-DD ([how it resolved])
+-->
+
+## Open Questions
+
+<!-- Unresolved questions that may be blocking progress.
+     When resolved, check the box and add a Decisions entry below.
+- [ ] Question text *(asked by Name, YYYY-MM-DD)*
+-->
+
+## Decisions
+
+<!-- Structured record of key decisions made on this entity.
+     Agent will propose an entry when decision language is detected during ingestion or conversation.
+     ### [YYYY-MM-DD] Decision title
+     - **Decided by:** Name
+     - **Recorded by:** Name or Claude (ingestion)
+     - **Options considered:** Option A (rejected: reason), Option B (rejected: reason), chosen option
+     - **Rationale:** Why this option was chosen
+-->

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-resource-parser/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-resource-parser/workitem.md
@@ -4,7 +4,7 @@
 
 - State: Active
 - Type: Story
-- Iteration: Sprint 2026-08
+- Iteration: 260415-260428
 - External URL:
 - Assigned to: marcus.chen@riverdale.org
 

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-validation-suite/workitem.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/fhir-r4-support/workitems/fhir-validation-suite/workitem.md
@@ -2,11 +2,12 @@
 
 ## Properties
 
-- State: New
+- State: Active
 - Type: Story
-- Iteration:
+- Iteration: 260415-260428
 - External URL:
-- Assigned to:
+- Assigned to: marcus.chen@riverdale.org
+- Blocked: Yes
 
 ## Description
 
@@ -25,3 +26,11 @@ None.
 ## Items this depends on
 
 FHIR Resource Parser.
+
+## Blockers
+
+### 2026-04-18 US Core profile definitions not yet available in test environment
+- **Flagged by:** Marcus Chen
+- **Cause:** External — waiting on platform team to publish US Core profile bundle to the validation sandbox
+- **Follow-up:** 2026-04-25 — checking back with platform team
+- **Status:** Active

--- a/Example/backlog/epics/ehr-pipeline-modernization/features/streaming-ingestion/feature.md
+++ b/Example/backlog/epics/ehr-pipeline-modernization/features/streaming-ingestion/feature.md
@@ -29,3 +29,7 @@ Part of epic: EHR Pipeline Modernization
 ## Items this depends on
 
 FHIR R4 Support — streaming events will use FHIR format.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Example/backlog/epics/operational-reporting-v2/epic.md
+++ b/Example/backlog/epics/operational-reporting-v2/epic.md
@@ -21,3 +21,7 @@ Impacts product: Operational Dashboards
 ## Items this depends on
 
 Partially depends on EHR Pipeline Modernization — streaming ingestion enables real-time census.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child features and their status.]

--- a/Example/backlog/epics/operational-reporting-v2/features/department-kpi-feeds/feature.md
+++ b/Example/backlog/epics/operational-reporting-v2/features/department-kpi-feeds/feature.md
@@ -29,3 +29,7 @@ Part of epic: Operational Reporting V2
 ## Items this depends on
 
 None.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Example/backlog/epics/operational-reporting-v2/features/realtime-census-dashboard/feature.md
+++ b/Example/backlog/epics/operational-reporting-v2/features/realtime-census-dashboard/feature.md
@@ -29,3 +29,7 @@ Part of epic: Operational Reporting V2
 ## Items this depends on
 
 Depends on Streaming Ingestion feature from EHR Pipeline Modernization epic.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Example/backlog/epics/operational-reporting-v2/features/self-service-data-access/feature.md
+++ b/Example/backlog/epics/operational-reporting-v2/features/self-service-data-access/feature.md
@@ -29,3 +29,7 @@ Part of epic: Operational Reporting V2
 ## Items this depends on
 
 Department KPI Feeds — catalog needs standardized metrics to index.
+
+## Child Summary
+
+[Auto-maintained by /rollup-backlog. Summary of child work items and their status.]

--- a/Fabric/.claude/commands/personal-backlog.md
+++ b/Fabric/.claude/commands/personal-backlog.md
@@ -1,0 +1,119 @@
+# /personal-backlog — Personal Work Queue
+
+## Usage
+
+```
+/personal-backlog
+```
+
+Generates (or refreshes) `output/personal-backlog.md` — a quick-reference list of backlog items assigned to the current user.
+
+## Behavior
+
+### 1. Resolve Identity
+
+Invoke the `identity` skill to identify the current user. If identity cannot be resolved (no matching email in member profiles), inform the user and stop:
+
+> "I couldn't match your git email to a team member profile. Personal backlog requires a matched profile — ask someone with meta mode access to run /add-member if you're new."
+
+### 2. Determine Iteration Filter
+
+Read `### Iterations` from the team's `CLAUDE.md`. If `Iteration Start:` and `Iteration Duration:` are present, compute the current iteration name using:
+
+```
+n             = floor((today − Iteration Start) / Iteration Duration)
+current_start = Iteration Start + n × Iteration Duration
+current_end   = current_start + Iteration Duration − 1
+name          = YYMMDD-YYMMDD  (e.g. 260401-260414)
+```
+
+If the `### Iterations` subsection is absent, there is no iteration filter — show all non-terminal assigned items.
+
+### 3. Scan the Backlog
+
+Scan all entity files in `backlog/` recursively (work items and tasks at every depth). Do not scan `backlog/inbox/`. For each file, check whether the `Assigned to:` property matches the resolved member's email. Matching is case-insensitive.
+
+**State filter:**
+- **With iteration config:** Include items where `Iteration:` matches the current iteration name, OR items in `Active` state with no `Iteration:` set. Also include any items in `Closed` state whose `Terminated:` date falls within the current iteration window (these go in the "Closed this sprint" group).
+- **Without iteration config:** Include all items where `State:` is not `Closed` or `Removed`.
+
+### 4. Group and Sort
+
+Group collected items into up to four buckets, in this order:
+
+| Group | Criteria |
+|-------|----------|
+| Active | `State: Active` and no non-empty `## Blockers` section with an Active entry |
+| New | `State: New` |
+| Blocked | `State: Active` with a `## Blockers` section containing at least one `Status: Active` entry |
+| Closed this sprint | `State: Closed` (iteration config only) |
+
+Items in Blocked are removed from Active — they must not appear in both groups.
+
+Within each group, sort by `Priority:` descending (highest number first). Items without a `Priority:` value sort to the bottom of their group.
+
+### 5. Write the Report
+
+Ensure `output/` exists at the instance root (create if needed). Write `output/personal-backlog.md`, overwriting any prior version:
+
+```markdown
+# Personal Backlog — [Member Name]
+Generated: YYYY-MM-DD
+
+*Current iteration: YYMMDD-YYMMDD*
+
+## Active ([n])
+
+| Item | Type | Priority | Iteration |
+|------|------|----------|-----------|
+| [Title](../relative/path/to/workitem.md) | Story | 3 | 260415-260428 |
+
+## New ([n])
+
+| Item | Type | Priority | Iteration |
+|------|------|----------|-----------|
+| [Title](../relative/path/to/workitem.md) | Story | — | 260415-260428 |
+
+## Blocked ([n])
+
+| Item | Type | Iteration |
+|------|------|-----------|
+| [Title](../relative/path/to/workitem.md) | Story | 260415-260428 |
+
+## Closed this Sprint ([n])
+
+| Item | Type | Terminated |
+|------|------|------------|
+| [Title](../relative/path/to/workitem.md) | Story | 2026-04-10 |
+```
+
+**Relative links:** Each item's link is a relative path from `output/personal-backlog.md` to the entity file (e.g. `../backlog/epics/ehr-pipeline/features/fhir-r4/workitems/fhir-parser/workitem.md`).
+
+**Empty groups:** Omit the table and show `*(none)*` instead. Always emit the group header so the section is visible even when empty.
+
+**Omit columns** that are entirely empty across all items in a group (e.g. if no items in the Active group have a Priority set, omit the Priority column for that table). The Type and Item columns are always present.
+
+**The "Current iteration" line** is omitted when no iteration config is present.
+
+**Tasks vs Work Items:** Display both. For tasks, append the parent work item name in italic after the title: `Implement parser *(fhir-resource-parser)*`. The parent is the work item folder name containing the `tasks/` directory.
+
+### 6. Confirm Output
+
+Confirm the file was written or refreshed:
+
+> "Personal backlog written to `output/personal-backlog.md` — [n] items across [list of non-empty groups]."
+
+If no items were found, explain the filter that was applied:
+
+> "No assigned items found for [Name]. Filter applied: current iteration 260415-260428 (plus Active items with no iteration set)."
+
+or, without iteration config:
+
+> "No assigned items found for [Name] across all non-terminal states."
+
+## Notes
+
+- Read-only command. No meta mode required.
+- Running the command again refreshes `output/personal-backlog.md` in place.
+- Does not scan `backlog/inbox/` — inbox items are unassigned by definition.
+- Does not scan `requests/` — request assignments are managed by the Triage module.

--- a/Fabric/.claude/commands/personal-backlog.md
+++ b/Fabric/.claude/commands/personal-backlog.md
@@ -6,7 +6,7 @@
 /personal-backlog
 ```
 
-Generates (or refreshes) `output/personal-backlog.md` — a quick-reference list of backlog items assigned to the current user.
+Generates (or refreshes) `output/personal-backlog.md` — a quick-reference view of the current user's assigned work, grouped by feature.
 
 ## Behavior
 
@@ -31,28 +31,41 @@ If the `### Iterations` subsection is absent, there is no iteration filter — s
 
 ### 3. Scan the Backlog
 
-Scan all entity files in `backlog/` recursively (work items and tasks at every depth). Do not scan `backlog/inbox/`. For each file, check whether the `Assigned to:` property matches the resolved member's email. Matching is case-insensitive.
+Scan all entity files in `backlog/` recursively. Do not scan `backlog/inbox/`. For each file, check whether the `Assigned to:` property matches the resolved member's email (case-insensitive). Collect matching features, work items, and tasks separately.
 
 **State filter:**
-- **With iteration config:** Include items where `Iteration:` matches the current iteration name, OR items in `Active` state with no `Iteration:` set. Also include any items in `Closed` state whose `Terminated:` date falls within the current iteration window (these go in the "Closed this sprint" group).
-- **Without iteration config:** Include all items where `State:` is not `Closed` or `Removed`.
+- **With iteration config:** Include features and work items where `Iteration:` matches the current iteration name, OR items in `Active` state with no `Iteration:` set. Include `Closed` items whose `Terminated:` date falls within the current iteration window (these go in the "Closed this sprint" group). Features do not have an `Iteration:` field — include assigned features whose `State:` is non-terminal (not Closed or Removed).
+- **Without iteration config:** Include all features, work items, and tasks where `State:` is not `Closed` or `Removed`.
 
-### 4. Group and Sort
+### 4. Group by State
 
-Group collected items into up to four buckets, in this order:
+Assign each item to one of four state groups:
 
 | Group | Criteria |
 |-------|----------|
-| Active | `State: Active` and no non-empty `## Blockers` section with an Active entry |
+| Active | `State: Active` and `## Blockers` has no `Status: Active` entry |
 | New | `State: New` |
-| Blocked | `State: Active` with a `## Blockers` section containing at least one `Status: Active` entry |
+| Blocked | `State: Active` with at least one `Status: Active` entry in `## Blockers` |
 | Closed this sprint | `State: Closed` (iteration config only) |
 
-Items in Blocked are removed from Active — they must not appear in both groups.
+Items in Blocked are removed from Active — they must not appear in both groups. Each item appears in exactly one group, determined by its own state.
 
-Within each group, sort by `Priority:` descending (highest number first). Items without a `Priority:` value sort to the bottom of their group.
+### 5. Build the Feature Tree
 
-### 5. Write the Report
+Within each state group, organize items under their parent feature:
+
+- **For work items and tasks:** identify the parent feature from the folder path (the `features/<feature-id>/` ancestor in the file's path). Load the feature title and path from its `feature.md`.
+- **For features assigned directly to the user:** the feature itself is the top-level item.
+
+A feature header appears in a state group when any of the following is true:
+1. The feature itself is assigned to the user and its state falls in that group.
+2. One or more child work items or tasks assigned to the user have a state that falls in that group.
+
+The same feature may appear as a header in multiple state groups if its children have different states (e.g., some Active, some Blocked).
+
+Sort features within each group by `Priority:` descending. Items without `Priority:` sort to the bottom.
+
+### 6. Write the Report
 
 Ensure `output/` exists at the instance root (create if needed). Write `output/personal-backlog.md`, overwriting any prior version:
 
@@ -62,58 +75,53 @@ Generated: YYYY-MM-DD
 
 *Current iteration: YYMMDD-YYMMDD*
 
-## Active ([n])
+## Active
 
-| Item | Type | Priority | Iteration |
-|------|------|----------|-----------|
-| [Title](../relative/path/to/workitem.md) | Story | 3 | 260415-260428 |
+### [FHIR R4 Support](../backlog/epics/ehr-pipeline/features/fhir-r4-support/feature.md) *(yours)*
+- [FHIR Resource Parser](../backlog/.../workitem.md) — Story · 260415-260428
+- [ADT Event Mapping](../backlog/.../workitem.md) — Story · 260415-260428
 
-## New ([n])
+### [Data Lineage Tracking](../backlog/.../feature.md)
+- [dbt Lineage Integration](../backlog/.../workitem.md) — Story
 
-| Item | Type | Priority | Iteration |
-|------|------|----------|-----------|
-| [Title](../relative/path/to/workitem.md) | Story | — | 260415-260428 |
+## New
 
-## Blocked ([n])
+### [FHIR R4 Support](../backlog/.../feature.md) *(yours)*
+- [ADT Event Mapping](../backlog/.../workitem.md) — Story · 260415-260428
 
-| Item | Type | Iteration |
-|------|------|-----------|
-| [Title](../relative/path/to/workitem.md) | Story | 260415-260428 |
+## Blocked
 
-## Closed this Sprint ([n])
+### [FHIR R4 Support](../backlog/.../feature.md) *(yours)*
+- [FHIR Validation Suite](../backlog/.../workitem.md) — Story · 260415-260428 ⚠ blocked
 
-| Item | Type | Terminated |
-|------|------|------------|
-| [Title](../relative/path/to/workitem.md) | Story | 2026-04-10 |
+## Closed this Sprint
+
+### [FHIR R4 Support](../backlog/.../feature.md) *(yours)*
+- [Schema Registry](../backlog/.../workitem.md) — Story · closed 2026-04-20
 ```
 
-**Relative links:** Each item's link is a relative path from `output/personal-backlog.md` to the entity file (e.g. `../backlog/epics/ehr-pipeline/features/fhir-r4/workitems/fhir-parser/workitem.md`).
+**Formatting rules:**
 
-**Empty groups:** Omit the table and show `*(none)*` instead. Always emit the group header so the section is visible even when empty.
+- `*(yours)*` appears on the feature header only when the feature itself is assigned to the user. Features used only as grouping context have no tag.
+- **Relative links:** paths are relative from `output/personal-backlog.md` (e.g. `../backlog/epics/.../feature.md`).
+- **Item line format:** `- [Title](../path) — Type · Iteration` where Type is the work item's `Type:` field (Story, Bug, etc.) and Iteration is omitted when blank. For tasks, omit Type and append the parent work item name in italic: `- [Task Title](../path) — *(workitem-name)*`.
+- **Features assigned to user with no child items in this group:** show the feature header alone with no bullet list beneath it (it is its own item).
+- **The "Current iteration" line** is omitted when no iteration config is present.
+- **Empty groups:** omit the group entirely — do not emit empty `## Active` headers.
 
-**Omit columns** that are entirely empty across all items in a group (e.g. if no items in the Active group have a Priority set, omit the Priority column for that table). The Type and Item columns are always present.
-
-**The "Current iteration" line** is omitted when no iteration config is present.
-
-**Tasks vs Work Items:** Display both. For tasks, append the parent work item name in italic after the title: `Implement parser *(fhir-resource-parser)*`. The parent is the work item folder name containing the `tasks/` directory.
-
-### 6. Confirm Output
+### 7. Confirm Output
 
 Confirm the file was written or refreshed:
 
 > "Personal backlog written to `output/personal-backlog.md` — [n] items across [list of non-empty groups]."
 
-If no items were found, explain the filter that was applied:
+If no items were found:
 
 > "No assigned items found for [Name]. Filter applied: current iteration 260415-260428 (plus Active items with no iteration set)."
-
-or, without iteration config:
-
-> "No assigned items found for [Name] across all non-terminal states."
 
 ## Notes
 
 - Read-only command. No meta mode required.
 - Running the command again refreshes `output/personal-backlog.md` in place.
-- Does not scan `backlog/inbox/` — inbox items are unassigned by definition.
+- Does not scan `backlog/inbox/`.
 - Does not scan `requests/` — request assignments are managed by the Triage module.

--- a/Fabric/backlog/template-feature.md
+++ b/Fabric/backlog/template-feature.md
@@ -13,6 +13,7 @@
 - Duration: [optional, how long the feature is estimated to take once started]
 - Priority: [optional 1(lowest)-5(highest) representing the priority of the feature]
 - Area: [optional area path representing a product or service line]
+- Assigned to: [optional — email of the team member primarily responsible for this feature]
 - Effort: [actual hours spent, populated on close]
 - Labels: [optional, comma-separated key=value pairs matching the team's label schema, e.g. service-type=data-extraction, security-sensitive=true]
 

--- a/Fabric/template/fabric-backlog.md
+++ b/Fabric/template/fabric-backlog.md
@@ -410,6 +410,7 @@ After promotion, the feature is a normal backlog item under its parent epic — 
 |---------|-------------|
 | /refine | Enter a backlog refinement conversation. Accepts an entity target, inbox item, or request ID. |
 | /rollup-backlog | Refresh Child Summary sections on epics and features. |
+| /personal-backlog | Generate a personal work queue for the current user, filtered to the current iteration if configured. |
 
 ## Skills
 

--- a/Fabric/template/fabric-backlog.md
+++ b/Fabric/template/fabric-backlog.md
@@ -94,6 +94,7 @@ Properties:
 - Priority: [optional 1(lowest)-5(highest)]
 - Size: [optional, relative size estimate — any numeric value or ?. Fibonacci sequence (1, 2, 3, 5, 8, 13, 21) is conventional but not enforced. Distinct from Effort and task hour fields.]
 - Area: [optional area path representing a product or service line]
+- Assigned to: [optional — email of the team member primarily responsible for this feature]
 - Effort: [optional, direct hours at the feature level — refinement, design, or coordination work not captured in child work items; also used by teams that track at the feature level without breaking down further]
 - Labels: [optional, comma-separated key=value pairs e.g. service-type=data-extraction]
 

--- a/Fabric/template/fabric-standup.md
+++ b/Fabric/template/fabric-standup.md
@@ -22,6 +22,16 @@ Valid day names: Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.
 
 When `Schedule:` is set, the `standup-report` skill uses it to determine which members are expected to have checked in for the current cycle, rather than treating any gap as a missing update.
 
+Teams may also configure section label terminology using the `Terminology:` key. This is useful for teams that meet on a weekly cadence, where "Yesterday" and "Today" don't match how members think about the check-in period:
+
+```markdown
+### Standup
+Schedule: Thursday
+Terminology: Use "Since Last Week" and "This Next Week" instead of "Yesterday" and "Today".
+```
+
+`Terminology:` is a free-form instruction. The agent interprets it to derive the two section labels and applies them throughout the standup conversation and written record. Teams that do not set `Terminology:` default to "Yesterday" and "Today".
+
 ## Directory Structure
 
 ```
@@ -62,6 +72,17 @@ Members who have not run `/standup-discussion` since the last team standup are n
 
 When a `Schedule:` is configured, a member is only considered missing for a cycle if at least one scheduled standup day has passed since the last team standup. A gap that falls entirely between scheduled days is expected, not a missing update.
 
+### Standup Terminology
+
+When `Terminology:` is set in the `### Standup` config, both `/standup-discussion` and `standup-report` read it at the start of each session and derive two section labels — the "yesterday" label (what was done since the last standup) and the "today" label (what will be done until the next standup).
+
+The labels are applied consistently:
+- Section headers in `discuss-today.md` use the configured labels instead of "Yesterday" and "Today"
+- The conversation uses the configured labels in questions and prompts
+- Per-member summaries in `standup-today.md` use the configured labels in the bold summary lines
+
+Teams that do not set `Terminology:` see no change — "Yesterday" and "Today" remain the defaults.
+
 ### Member File Lifecycle
 
 - `discuss-today.md` is created or overwritten each time a member completes `/standup-discussion`.
@@ -100,6 +121,8 @@ Each `discuss-today.md` uses this structure:
 ## Notes
 [Any additional context from the conversation — omit section if none]
 ```
+
+When the team has configured `Terminology:` in their CLAUDE.md, the `## Yesterday` and `## Today` headers are replaced with the team's preferred labels (e.g., `## Since Last Week` and `## This Next Week`). All other sections remain unchanged.
 
 ### Backlog Notes from Standup
 


### PR DESCRIPTION
- Adds `/personal-backlog` command that scans the backlog for items assigned to the current user and writes `output/personal-backlog.md` as a quick-reference work queue
- Resolves identity via git email, filters to the current iteration if configured, groups results by parent feature in a markdown tree
- Adds `Assigned to:` as an optional property on Features, enabling feature-level ownership alongside work item and task assignment
- Updates Example instance with assigned work items and a feature assignment on `fhir-r4-support` to demonstrate the command
- [ ] Run `/personal-backlog` in the Example instance as `marcus.chen@riverdale.org` — should produce `output/personal-backlog.md` grouped under the FHIR R4 Support feature with Active, New, and Blocked sections
- [ ] Verify `*(yours)*` tag appears on the feature header (feature is assigned to marcus)
- [ ] Verify blocked item (`fhir-validation-suite`) appears in Blocked group, not Active
- [ ] Run the command a second time and confirm the file is refreshed in place
- [ ] Verify a member with no assigned items gets a "no items found" message with filter explanation